### PR TITLE
Add #sm7150-mainline

### DIFF
--- a/templates/irclogger/oftc.yml
+++ b/templates/irclogger/oftc.yml
@@ -37,6 +37,7 @@ channels:
   - "#ubuntu-asahi"
   - "#msm8937-mainline"
   - "#sm8250-mainline"
+  - "#sm7150-mainline"
 
 domain: {{domain}}
 


### PR DESCRIPTION
Allow the channel #sm8250-mainline to be logged.

This channel is bridged to Matrix. I am an operator in this channel along with JIaxyga and Adrian/gelbpunkt.